### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/update_rank.py
+++ b/update_rank.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 
 # Define base URL for historical PyPI data
-BASE_URL = "https://raw.githubusercontent.com/hugovk/top-pypi-packages/refs/tags/{year}.{month:02d}/top-pypi-packages-30-days.json"
+BASE_URL = "https://raw.githubusercontent.com/hugovk/top-pypi-packages/refs/tags/{year}.{month:02d}/top-pypi-packages.json"
 
 # Start tracking from September 2024
 start_year = 2024


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.

You'll need to make some adjustments if you want to use this with historical tags as well.